### PR TITLE
fix: offset vertices to keep bar in stable position

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Health Bar plugin for Bevy 3D. Despite its name, this plugin is universally applicable. It can be used to render a bar 
 for any value that can be represented as percentage.
 
-<img src="https://user-images.githubusercontent.com/2863630/236912868-490ac178-ebd5-4389-a69e-64160b3c56e5.gif" width="300" />
+<img src="https://github.com/sparten11740/bevy_health_bar3d/assets/2863630/31c50809-30f0-45fc-8639-054db7c96429" width="300" />
 
 
 ## Bevy Compatibility

--- a/assets/shaders/bar.wgsl
+++ b/assets/shaders/bar.wgsl
@@ -11,13 +11,14 @@ var<uniform> high_color: vec4<f32>;
 var<uniform> moderate_color: vec4<f32>;
 @group(1) @binding(4)
 var<uniform> low_color: vec4<f32>;
-
-#ifdef HAS_BORDER
 @group(1) @binding(5)
-var<uniform> border_width: f32;
+var<uniform> offset: vec3<f32>;
+#ifdef HAS_BORDER
 @group(1) @binding(6)
 var<uniform> resolution: vec2<f32>;
 @group(1) @binding(7)
+var<uniform> border_width: f32;
+@group(1) @binding(8)
 var<uniform> border_color: vec4<f32>;
 #endif
 
@@ -39,8 +40,8 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     let camera_right = normalize(vec3<f32>(view_proj.x.x, view_proj.y.x, view_proj.z.x));
     let camera_up = normalize(vec3<f32>(view_proj.x.y, view_proj.y.y, view_proj.z.y));
 
-    let world_space = camera_right * vertex.position.x + camera_up * vertex.position.y;
-    let position = view.view_proj * mesh.model * vec4<f32>(world_space, 1.0);
+    let world_space = camera_right * (vertex.position.x + offset.x) + camera_up * (vertex.position.y + offset.y);
+    let position = view.view_proj * mesh.model * vec4<f32>(world_space, 1.);
 
     out.uv = vertex.uv;
     out.clip_position = position;

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,5 +1,5 @@
 use bevy::pbr::{AlphaMode, Material, MaterialPipeline, MaterialPipelineKey};
-use bevy::prelude::{Color, Mesh, Vec2};
+use bevy::prelude::{Color, Mesh, Vec2, Vec3};
 use bevy::reflect::TypeUuid;
 use bevy::render::mesh::MeshVertexBufferLayout;
 use bevy::render::render_resource::{
@@ -21,10 +21,12 @@ pub(crate) struct HealthBarMaterial {
     #[uniform(4)]
     pub low_color: Color,
     #[uniform(5)]
-    pub border_width: f32,
+    pub offset: Vec3,
     #[uniform(6)]
     pub resolution: Vec2,
     #[uniform(7)]
+    pub border_width: f32,
+    #[uniform(8)]
     pub border_color: Color,
     pub vertical: bool,
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -4,7 +4,7 @@ use bevy::pbr::{NotShadowCaster, NotShadowReceiver};
 use bevy::prelude::{
     default, shape, Added, App, Assets, BuildChildren, Changed, Commands, Component, Entity,
     Handle, MaterialMeshBundle, MaterialPlugin, Mesh, Name, Plugin, Query, Reflect, Res, ResMut,
-    Transform, Vec2, Vec3,
+    Vec2, Vec3,
 };
 
 use crate::configuration::{BarHeight, BarOffset, BarWidth, ForegroundColor, Percentage};
@@ -95,8 +95,7 @@ fn spawn<T: Percentage + Component>(
                 )
             });
 
-            let offset = offset.map(|it| it.get()).unwrap_or(0.);
-            let transform = Transform::from_translation(offset * offset_axis);
+            let offset = offset.map(|it| it.get()).unwrap_or(0.) * offset_axis;
 
             let (high, moderate, low) = match color_scheme.foreground_color {
                 ForegroundColor::Static(color) => (color, color, color),
@@ -117,6 +116,7 @@ fn spawn<T: Percentage + Component>(
                 moderate_color: moderate,
                 low_color: low,
                 vertical,
+                offset,
                 resolution: Vec2::new(width, height),
                 border_width: border.width,
                 border_color: border.color,
@@ -134,7 +134,7 @@ fn spawn<T: Percentage + Component>(
                     MaterialMeshBundle {
                         mesh,
                         material,
-                        transform,
+                        // transform,
                         ..default()
                     },
                     NotShadowCaster,


### PR DESCRIPTION
Initially the offset was added as translation on the quad used for the health bar. This was dependant on camera movement/angle and resulted in bars moving around. This PR fixes the issue by keeping the quad at the center of its base mesh and adding the offset to the vertex positions inside the shader.

Updated GIF with bars that keep their alignment when the camera moves:

<img width="300" src="https://github.com/sparten11740/bevy_health_bar3d/assets/2863630/31c50809-30f0-45fc-8639-054db7c96429" />
