### PR TITLE
feat: despawn bar when tracked component is removed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_health_bar3d"
-description = "Simple healthbar for bevy implemented as a billboard shader"
+description = "Health bar for bevy implemented as a billboard shader"
 version = "1.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/examples/dinosaurs.rs
+++ b/examples/dinosaurs.rs
@@ -216,18 +216,20 @@ fn setup_idle_animation(
 
 fn kill_trex(
     animations: Res<Animations>,
-    mut query: Query<(&mut Health, &WithAnimationPlayer), Without<Distance>>,
+    mut commands: Commands,
+    mut query: Query<(&mut Health, &WithAnimationPlayer, Entity), Without<Distance>>,
     mut players: Query<&mut AnimationPlayer>,
     time: Res<Time>,
 ) {
     query
         .iter_mut()
-        .filter(|(health, _)| health.current > 0.)
-        .for_each(|(mut health, with_animation_player)| {
+        .filter(|(health, _, _)| health.current > 0.)
+        .for_each(|(mut health, with_animation_player, entity)| {
             let delta_z = time.delta_seconds();
             health.current -= delta_z;
 
             if health.current <= 0.01 {
+                commands.entity(entity).remove::<Health>();
                 players
                     .get_mut(with_animation_player.0)
                     .unwrap()

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,10 +1,11 @@
 use std::marker::PhantomData;
 
+use bevy::log::warn;
 use bevy::pbr::{NotShadowCaster, NotShadowReceiver};
 use bevy::prelude::{
-    default, shape, Added, App, Assets, BuildChildren, Changed, Commands, Component, Entity,
-    Handle, MaterialMeshBundle, MaterialPlugin, Mesh, Name, Plugin, Query, Reflect, Res, ResMut,
-    Vec2, Vec3,
+    default, shape, Added, App, Assets, BuildChildren, Changed, Commands, Component,
+    DespawnRecursiveExt, Entity, Handle, MaterialMeshBundle, MaterialPlugin, Mesh, Name, Plugin,
+    Query, Reflect, RemovedComponents, Res, ResMut, Vec2, Vec3,
 };
 
 use crate::configuration::{BarHeight, BarOffset, BarWidth, ForegroundColor, Percentage};
@@ -37,6 +38,7 @@ impl<T: Percentage + Component> Plugin for HealthBarPlugin<T> {
             .register_type::<BarWidth<T>>()
             .register_type::<BarOffset<T>>()
             .add_system(spawn::<T>)
+            .add_system(remove::<T>)
             .add_system(update::<T>);
     }
 }
@@ -162,4 +164,19 @@ fn update<T: Percentage + Component>(
             let material = materials.get_mut(material_handle).unwrap();
             material.value = hitpoints.value();
         });
+}
+
+fn remove<T: Percentage + Component>(
+    mut commands: Commands,
+    mut removals: RemovedComponents<T>,
+    parent_query: Query<&WithHealthBar>,
+) {
+    removals.iter().for_each(|entity| {
+        let Ok(&WithHealthBar(bar_entity)) = parent_query.get(entity) else {
+            warn!("Tracked component {:?} was removed, but couldn't find bar to despawn.", entity);
+            return
+        };
+
+        commands.entity(bar_entity).despawn_recursive()
+    });
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,11 +2,7 @@ use std::marker::PhantomData;
 
 use bevy::log::warn;
 use bevy::pbr::{NotShadowCaster, NotShadowReceiver};
-use bevy::prelude::{
-    default, shape, Added, App, Assets, BuildChildren, Changed, Commands, Component,
-    DespawnRecursiveExt, Entity, Handle, MaterialMeshBundle, MaterialPlugin, Mesh, Name, Plugin,
-    Query, Reflect, RemovedComponents, Res, ResMut, Vec2, Vec3,
-};
+use bevy::prelude::*;
 
 use crate::configuration::{BarHeight, BarOffset, BarWidth, ForegroundColor, Percentage};
 use crate::constants::{DEFAULT_RELATIVE_HEIGHT, DEFAULT_WIDTH};

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -33,9 +33,7 @@ impl<T: Percentage + Component> Plugin for HealthBarPlugin<T> {
             .init_resource::<ColorScheme<T>>()
             .register_type::<BarWidth<T>>()
             .register_type::<BarOffset<T>>()
-            .add_system(spawn::<T>)
-            .add_system(remove::<T>)
-            .add_system(update::<T>);
+            .add_systems((spawn::<T>, remove::<T>, update::<T>));
     }
 }
 


### PR DESCRIPTION
Automatically removes the bar when the tracked component is removed, and therefore no-longer requires manual despawning.

See dinosaur example to see this in action