### PR TITLE
feat!: use a single BarSettings component

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ fn main() {
 }
 ```
 
-Spawn a mesh, the component to be tracked, and a `BarBundle` to configure the look & feel of your bar.
+Spawn a mesh, the component to be tracked, and a `BarSettings` component to configure the look & feel of your bar.
 
 ```rust
 fn setup(
@@ -69,9 +69,9 @@ fn setup(
             max: 10.,
             current: 2.,
         },
-        BarBundle::<Health> {
-            width: BarWidth::new(mesh_width),
-            offset: BarOffset::new(mesh_height),
+        BarSettings::<Health> {
+            width: 5.,
+            offset: 2.,
             orientation: BarOrientation::Vertical, // default is horizontal
             ..default()
         },

--- a/examples/border.rs
+++ b/examples/border.rs
@@ -6,9 +6,7 @@ use bevy::utils::default;
 use bevy::DefaultPlugins;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
-use bevy_health_bar3d::prelude::{
-    BarBorder, BarBundle, BarHeight, BarOffset, BarWidth, HealthBarPlugin, Percentage,
-};
+use bevy_health_bar3d::prelude::{BarBorder, BarHeight, BarSettings, HealthBarPlugin, Percentage};
 
 #[derive(Component, Reflect)]
 struct Health {
@@ -76,9 +74,9 @@ fn setup(
                 max: 10.,
                 current: value,
             },
-            BarBundle::<Health> {
-                offset: BarOffset::new(offset),
-                width: BarWidth::new(bar_width),
+            BarSettings::<Health> {
+                offset,
+                width: bar_width,
                 height: BarHeight::Static(bar_height),
                 // here is where the border is defined
                 border: BarBorder::new(bar_height / 4.).color(Color::PURPLE),

--- a/examples/custom_background.rs
+++ b/examples/custom_background.rs
@@ -6,9 +6,7 @@ use bevy::utils::default;
 use bevy::DefaultPlugins;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
-use bevy_health_bar3d::prelude::{
-    BarBundle, BarOffset, BarWidth, ColorScheme, HealthBarPlugin, Percentage,
-};
+use bevy_health_bar3d::prelude::{BarSettings, ColorScheme, HealthBarPlugin, Percentage};
 
 #[derive(Component, Reflect)]
 struct Health {
@@ -69,9 +67,9 @@ fn setup(
             max: 10.,
             current: 8.,
         },
-        BarBundle::<Health> {
-            offset: BarOffset::new(radius * 1.5),
-            width: BarWidth::new(radius * 2.),
+        BarSettings::<Health> {
+            offset: radius * 1.5,
+            width: radius * 2.,
             ..default()
         },
     ));

--- a/examples/custom_foreground.rs
+++ b/examples/custom_foreground.rs
@@ -83,9 +83,9 @@ fn setup(
                 max: 10.,
                 current: value,
             },
-            BarBundle::<Mana> {
-                offset: BarOffset::new(radius * 1.5),
-                width: BarWidth::new(radius * 2.),
+            BarSettings::<Mana> {
+                offset: radius * 1.5,
+                width: radius * 2.,
                 ..default()
             },
         ));
@@ -107,9 +107,9 @@ fn setup(
                 max: 10.,
                 current: value,
             },
-            BarBundle::<Health> {
-                offset: BarOffset::new(radius * 1.5),
-                width: BarWidth::new(radius * 2.),
+            BarSettings::<Health> {
+                offset: radius * 1.5,
+                width: radius * 2.,
                 ..default()
             },
         ));

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -4,8 +4,9 @@ use bevy::pbr::*;
 use bevy::prelude::*;
 use bevy::utils::default;
 use bevy::DefaultPlugins;
-use bevy_health_bar3d::prelude::{BarBundle, BarOffset, BarWidth, HealthBarPlugin, Percentage};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
+
+use bevy_health_bar3d::prelude::{BarSettings, HealthBarPlugin, Percentage};
 
 #[derive(Component, Reflect)]
 struct Health {
@@ -66,9 +67,9 @@ fn setup(
             max: 10.,
             current: 8.,
         },
-        BarBundle::<Health> {
-            offset: BarOffset::new(radius * 1.5),
-            width: BarWidth::new(radius * 2.),
+        BarSettings::<Health> {
+            offset: radius * 1.5,
+            width: radius * 2.,
             ..default()
         },
     ));
@@ -90,9 +91,9 @@ fn setup(
             max: 10.,
             current: 2.,
         },
-        BarBundle::<Health> {
-            offset: BarOffset::new(radius * 1.5),
-            width: BarWidth::new(radius * 2.),
+        BarSettings::<Health> {
+            offset: radius * 1.5,
+            width: radius * 2.,
             ..default()
         },
     ));

--- a/examples/dinosaurs.rs
+++ b/examples/dinosaurs.rs
@@ -13,8 +13,7 @@ use bevy_tweening::lens::{TransformPositionLens, TransformRotationLens};
 use bevy_tweening::{Animator, EaseFunction, Tracks, Tween, TweeningPlugin};
 
 use bevy_health_bar3d::prelude::{
-    BarBundle, BarHeight, BarOffset, BarWidth, ColorScheme, ForegroundColor, HealthBarPlugin,
-    Percentage,
+    BarHeight, BarSettings, ColorScheme, ForegroundColor, HealthBarPlugin, Percentage,
 };
 
 #[derive(Component, Reflect)]
@@ -132,16 +131,16 @@ fn setup(
             max: 10.,
             current: 8.,
         },
-        BarBundle::<Distance> {
-            offset: BarOffset::new(15.),
+        BarSettings::<Distance> {
+            offset: 15.,
             height: BarHeight::Static(1.),
-            width: BarWidth::new(10.),
+            width: 10.,
             ..default()
         },
-        BarBundle::<Health> {
-            offset: BarOffset::new(17.),
+        BarSettings::<Health> {
+            offset: 17.,
             height: BarHeight::Static(1.),
-            width: BarWidth::new(10.),
+            width: 10.,
             ..default()
         },
     ));
@@ -153,10 +152,10 @@ fn setup(
             max: 10.,
             current: 10.,
         },
-        BarBundle::<Health> {
-            offset: BarOffset::new(17.),
+        BarSettings::<Health> {
+            offset: 17.,
             height: BarHeight::Static(1.),
-            width: BarWidth::new(10.),
+            width: 10.,
             ..default()
         },
     ));

--- a/examples/dual_bar.rs
+++ b/examples/dual_bar.rs
@@ -8,7 +8,7 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 use bevy_health_bar3d::configuration::ForegroundColor;
 use bevy_health_bar3d::prelude::{
-    BarBundle, BarHeight, BarOffset, BarWidth, ColorScheme, HealthBarPlugin, Percentage,
+    BarHeight, BarSettings, ColorScheme, HealthBarPlugin, Percentage,
 };
 
 #[derive(Component, Reflect)]
@@ -83,9 +83,9 @@ fn setup(
                 max: 10.,
                 current: value,
             },
-            BarBundle::<Health> {
-                offset: BarOffset::new(offset),
-                width: BarWidth::new(bar_width),
+            BarSettings::<Health> {
+                offset: offset,
+                width: bar_width,
                 height: BarHeight::Static(bar_height),
                 ..default()
             },
@@ -93,9 +93,9 @@ fn setup(
                 max: 10.,
                 current: values[2 - i],
             },
-            BarBundle::<Mana> {
-                offset: BarOffset::new(offset + bar_height + bar_height / 5.),
-                width: BarWidth::new(bar_width),
+            BarSettings::<Mana> {
+                offset: offset + bar_height + bar_height / 5.,
+                width: bar_width,
                 height: BarHeight::Static(bar_height),
                 ..default()
             },

--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -7,7 +7,7 @@ use bevy::utils::default;
 use bevy::DefaultPlugins;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
-use bevy_health_bar3d::prelude::{BarBundle, BarOffset, BarWidth, HealthBarPlugin, Percentage};
+use bevy_health_bar3d::prelude::{BarSettings, HealthBarPlugin, Percentage};
 
 #[derive(Component, Reflect)]
 struct Health {
@@ -59,9 +59,9 @@ fn setup(
             max: 10.,
             current: 10.,
         },
-        BarBundle::<Health> {
-            offset: BarOffset::new(radius * 1.5),
-            width: BarWidth::new(radius * 2.),
+        BarSettings::<Health> {
+            offset: radius * 1.5,
+            width: radius * 2.,
             ..default()
         },
     ));

--- a/examples/multi_camera.rs
+++ b/examples/multi_camera.rs
@@ -5,7 +5,7 @@ use bevy::pbr::*;
 use bevy::prelude::*;
 use bevy::utils::default;
 use bevy::DefaultPlugins;
-use bevy_health_bar3d::prelude::{BarBundle, BarOffset, BarWidth, HealthBarPlugin, Percentage};
+use bevy_health_bar3d::prelude::{BarSettings, HealthBarPlugin, Percentage};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 #[derive(Component, Reflect)]
@@ -67,9 +67,9 @@ fn setup(
             max: 10.,
             current: 8.,
         },
-        BarBundle::<Health> {
-            offset: BarOffset::new(radius * 1.5),
-            width: BarWidth::new(radius * 2.),
+        BarSettings::<Health> {
+            offset: radius * 1.5,
+            width: radius * 2.,
             ..default()
         },
     ));
@@ -91,9 +91,9 @@ fn setup(
             max: 10.,
             current: 2.,
         },
-        BarBundle::<Health> {
-            offset: BarOffset::new(radius * 1.5),
-            width: BarWidth::new(radius * 2.),
+        BarSettings::<Health> {
+            offset: radius * 1.5,
+            width: radius * 2.,
             ..default()
         },
     ));

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -11,9 +11,7 @@ use bevy::utils::default;
 use bevy::DefaultPlugins;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
-use bevy_health_bar3d::prelude::{
-    BarBundle, BarHeight, BarOffset, BarWidth, HealthBarPlugin, Percentage,
-};
+use bevy_health_bar3d::prelude::{BarHeight, BarSettings, HealthBarPlugin, Percentage};
 
 #[derive(Component, Reflect)]
 struct Health {
@@ -83,10 +81,10 @@ fn setup(
             max: 10.,
             current: 8.,
         },
-        BarBundle::<Health> {
-            offset: BarOffset::new(18.),
+        BarSettings::<Health> {
+            offset: 18.,
             height: BarHeight::Static(1.),
-            width: BarWidth::new(10.),
+            width: 10.,
             ..default()
         },
         Jim,
@@ -108,11 +106,11 @@ fn setup(
             max: 10.,
             current: 3.,
         },
-        BarBundle::<Health> {
+        BarSettings::<Health> {
             // Have to locate it higher than Jim's so there is no clipping during rotation
-            offset: BarOffset::new(21.),
+            offset: 21.,
             height: BarHeight::Static(1.),
-            width: BarWidth::new(10.),
+            width: 10.,
             ..default()
         },
         Tom,

--- a/examples/vertical.rs
+++ b/examples/vertical.rs
@@ -6,9 +6,7 @@ use bevy::utils::default;
 use bevy::DefaultPlugins;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
-use bevy_health_bar3d::prelude::{
-    BarBundle, BarOffset, BarOrientation, BarWidth, HealthBarPlugin, Percentage,
-};
+use bevy_health_bar3d::prelude::{BarOrientation, BarSettings, HealthBarPlugin, Percentage};
 
 #[derive(Component, Reflect)]
 struct Health {
@@ -70,9 +68,9 @@ fn setup(
             max: 10.,
             current: 8.,
         },
-        BarBundle::<Health> {
-            offset: BarOffset::new(radius * 1.5),
-            width: BarWidth::new(radius * 2.),
+        BarSettings::<Health> {
+            offset: radius * 1.5,
+            width: radius * 2.,
             orientation: BarOrientation::Vertical,
             ..default()
         },

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,4 +1,3 @@
-use std::convert::Infallible;
 use std::marker::PhantomData;
 
 use bevy::prelude::*;
@@ -9,91 +8,46 @@ use crate::constants::{
     DEFAULT_MODERATE_COLOR, DEFAULT_RELATIVE_HEIGHT, DEFAULT_WIDTH,
 };
 
-/// Bundle to customize multiple aspects at the same time
-#[derive(Bundle)]
-pub struct BarBundle<T: Percentage + Component + TypePath> {
-    pub offset: BarOffset<T>,
-    pub width: BarWidth<T>,
-    pub height: BarHeight<T>,
-    pub orientation: BarOrientation<T>,
-    pub border: BarBorder<T>,
+/// Component to configure a bar
+#[derive(Component, Debug, Clone, Reflect)]
+pub struct BarSettings<T: Percentage + Component + TypePath> {
+    /// Configure the width of the bar
+    pub width: f32,
+    /// Configures the offset of the bar relative to the entity its attached to.
+    /// For horizontal bars, this is an offset along the y-axis, for vertical bars along the x-axis.
+    pub offset: f32,
+    pub height: BarHeight,
+    pub border: BarBorder,
+    pub orientation: BarOrientation,
+    #[reflect(ignore)]
+    pub phantom_data: PhantomData<T>,
 }
 
-impl<T: Percentage + Component + TypePath> Default for BarBundle<T> {
+impl<T: Percentage + Component + TypePath> Default for BarSettings<T> {
     fn default() -> Self {
         Self {
-            offset: BarOffset::default(),
-            width: BarWidth::default(),
-            height: BarHeight::default(),
-            orientation: BarOrientation::default(),
-            border: BarBorder::default(),
+            width: DEFAULT_WIDTH,
+            offset: 0.0,
+            height: default(),
+            border: default(),
+            orientation: default(),
+            phantom_data: default(),
         }
     }
 }
 
-/// Component to configure the offset of the bar relative to the entity its attached to.
-/// For horizontal bars, this is an offset along the y-axis, for vertical bars along the x-axis.
-#[derive(Component, Debug, Clone, Reflect)]
-pub struct BarOffset<T: Percentage + Component + TypePath>(f32, #[reflect(ignore)] PhantomData<T>);
-
-impl<T: Percentage + Component + TypePath> BarOffset<T> {
-    pub fn new(offset: f32) -> Self {
-        Self(offset, PhantomData)
-    }
-
-    pub fn get(&self) -> f32 {
-        self.0
-    }
-}
-
-impl<T: Percentage + Component + TypePath> Default for BarOffset<T> {
-    fn default() -> Self {
-        Self::new(0.)
-    }
-}
-
-/// Component to configure the width of the bar
-#[derive(Component, Debug, Clone, Reflect)]
-pub struct BarWidth<T: Percentage + Component + TypePath>(f32, #[reflect(ignore)] PhantomData<T>);
-
-impl<T: Percentage + Component + TypePath> BarWidth<T> {
-    pub fn new(width: f32) -> Self {
-        Self(width, PhantomData)
-    }
-
-    pub fn get(&self) -> f32 {
-        self.0
-    }
-}
-
-impl<T: Percentage + Component + TypePath> Default for BarWidth<T> {
-    fn default() -> Self {
-        Self::new(DEFAULT_WIDTH)
-    }
-}
-
-/// Component to configure the border of the bar. Defaults to no border
-/// # Examples
-///
-/// ```
-/// use bevy::prelude::Color;
-/// use bevy_health_bar3d::prelude::BarBorder;
-/// commands.entity(entity).insert(BarBorder::<Health>::new(0.2).color(Color::PURPLE)); // configures the bar height to be 20% of its width
-/// ```
-#[derive(Component, Debug, Clone, Reflect)]
-pub struct BarBorder<T: Percentage + Component + TypePath> {
+/// Describes the border of a bar. Defaults to no border
+#[derive(Debug, Clone, Reflect)]
+pub struct BarBorder {
     pub width: f32,
     pub color: Color,
-    #[reflect(ignore)]
-    phantom_data: PhantomData<T>,
 }
 
-impl<T: Percentage + Component + TypePath> BarBorder<T> {
+impl BarBorder {
     pub fn new(width: f32) -> Self {
         Self {
             width,
             color: DEFAULT_BORDER_COLOR,
-            phantom_data: PhantomData,
         }
     }
 
@@ -103,55 +57,37 @@ impl<T: Percentage + Component + TypePath> BarBorder<T> {
     }
 }
 
-impl<T: Percentage + Component + TypePath> Default for BarBorder<T> {
+impl Default for BarBorder {
     fn default() -> Self {
         Self {
             width: 0.,
             color: DEFAULT_BORDER_COLOR,
-            phantom_data: PhantomData,
         }
     }
 }
 
-/// Component to configure the height of the bar
-///
-/// # Examples
-///
-/// ```
-/// use bevy_health_bar3d::prelude::BarHeight;
-/// commands.entity(entity).insert(BarHeight::<Health>::new(0.2)); // configures the bar height to be 20% of its width
-/// ```
-#[derive(Component, Debug, Clone)]
-pub enum BarHeight<T: Percentage + Component + TypePath> {
+/// Describes the height of the bar
+#[derive(Debug, Clone, Reflect)]
+pub enum BarHeight {
     /// Bar height relative to its width
     Relative(f32),
     /// Static bar width
     Static(f32),
-
-    _Internal(Infallible, PhantomData<T>),
 }
 
-impl<T: Percentage + Component + TypePath> Default for BarHeight<T> {
+impl Default for BarHeight {
     fn default() -> Self {
         Self::Relative(DEFAULT_RELATIVE_HEIGHT)
     }
 }
 
-/// Component to configure the height of the bar
-///
-/// # Examples
-///
+/// Describes the orientation a bar
 /// ```
-/// use bevy_health_bar3d::prelude::BarOrientation;
-/// commands.entity(entity).insert(BarOrientation::<Health>::Vertical);
-/// ```
-#[derive(Component, Debug, Clone, PartialEq, Eq, Default)]
-pub enum BarOrientation<T: Percentage + Component + TypePath> {
+#[derive(Reflect, Debug, Clone, PartialEq, Eq, Default)]
+pub enum BarOrientation {
     #[default]
     Horizontal,
     Vertical,
-
-    _Internal(Infallible, PhantomData<T>),
 }
 
 /// Trait implemented by the component to be tracked by the health bar


### PR DESCRIPTION
Use a single `BarSettings` component which is more ergonomic to handle. 

Closes #27 
Closes https://github.com/sparten11740/bevy_health_bar3d/issues/18

## Migration

```diff
-       BarBundle::<Health> {
-           width: BarWidth::new(mesh_width),
-           offset: BarOffset::new(mesh_height),
+       BarSettings::<Health> {
+           width: 5.,
+           offset: 2.,
            ..default()
        },
```
