### PR TITLE
fix: remove obsolete `exhaustive_patterns` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(exhaustive_patterns)]
-
 pub mod configuration;
 pub mod constants;
 mod material;


### PR DESCRIPTION
This is no longer needed as the generic enum(s) that required an infallible member with phantom data was removed in https://github.com/sparten11740/bevy_health_bar3d/pull/28

Closes #32 