### PR TITLE
refactor: update ordered-floats to version in bevy dependency tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = ["/src", "CHANGELOG.md", "/assets/shaders", "LICENSE-APACHE", "LICENSE
 
 [dependencies]
 bevy = { version = "0.16.1", default-features = false, features = ["bevy_pbr", "bevy_render"] }
-ordered-float = "3.9.2"
+ordered-float = "4.6.0"
 
 [dev-dependencies]
 bevy = "0.16.1"


### PR DESCRIPTION
Bevy 0.16.1 currently depends on ordered-float version 4.6.0. 
This updates the version used in this repo to the one used in bevy. 

The versions can be checked by running `cargo tree | grep ordered-float`.